### PR TITLE
Guard logging configuration

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -39,7 +39,6 @@ from fastapi.openapi.docs import (
 
 # ---- logging -----------------------------------------------------------------
 log = logging.getLogger("bambubridge")
-logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 
 # ---- pybambu import ----------------------------------------------------------
 try:
@@ -347,3 +346,9 @@ async def camera(name: str):
         raise
     except Exception as e:
         raise HTTPException(502, detail=f"camera stream error: {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))


### PR DESCRIPTION
## Summary
- avoid configuring global logging when bridge is imported by removing module-level `basicConfig`
- add `__main__` entry point to configure logging and launch uvicorn when run directly

## Testing
- `python -m py_compile bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc5cff69e4832f963189dd0f62198a