### PR TITLE
refactor: run app via main

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -397,7 +397,16 @@ async def camera(name: str):
         raise HTTPException(502, detail=f"camera stream error: {type(e).__name__}: {e}")
 
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+def main() -> None:
+    """Run the FastAPI application with a basic logging configuration."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wrap logging and server startup inside a `main` entry point

## Testing
- `python -m py_compile bridge.py`
- `pytest 2>&1 | tee /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68bc83c5b2dc832faca056505554afaf