### PR TITLE
Refactor printer state management

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -124,6 +124,11 @@ class PrinterState:
         async with self.lock:
             return dict(self.clients), dict(self.last_error)
 
+    async def clear(self) -> None:
+        async with self.lock:
+            self.clients.clear()
+            self.last_error.clear()
+
 
 state = PrinterState()
 
@@ -255,9 +260,7 @@ async def _shutdown() -> None:
             log.info("shutdown: disconnected %s", name)
         except Exception as e:
             log.warning("shutdown: disconnect(%s) failed: %s", name, e)
-    async with state.lock:
-        state.clients.clear()
-        state.last_error.clear()
+    await state.clear()
 
 
 # ---- routes ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `PrinterState.clear` for safe state resets under lock
- invoke `state.clear()` during shutdown to avoid direct dict access

## Testing
- `python -m py_compile bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc84a0f6ec832f854fb27babd355d6