### PR TITLE
Validate printer configuration at startup

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -163,6 +163,28 @@ USERNAME   = os.getenv("BAMBULAB_USERNAME", "")
 AUTH_TOKEN = os.getenv("BAMBULAB_AUTH_TOKEN", "")
 AUTOCONNECT= os.getenv("BAMBULAB_AUTOCONNECT", "0").lower() in {"1","true","yes","on"}
 
+
+def _validate_env() -> None:
+    """Cross-check name sets and ensure required fields exist."""
+    names = set(PRINTERS) | set(SERIALS) | set(LAN_KEYS) | set(TYPES)
+    missing_required: list[tuple[str, str]] = []
+    for n in names:
+        if n not in PRINTERS:
+            missing_required.append((n, "BAMBULAB_PRINTERS"))
+        if n not in SERIALS:
+            missing_required.append((n, "BAMBULAB_SERIALS"))
+        if n not in LAN_KEYS:
+            missing_required.append((n, "BAMBULAB_LAN_KEYS"))
+        if n not in TYPES:
+            log.warning("Missing BAMBULAB_TYPES for '%s'; defaulting to X1C", n)
+    if missing_required:
+        for name, env in missing_required:
+            log.error("Missing %s entry for '%s'", env, name)
+        raise RuntimeError("Printer configuration incomplete; check environment variables")
+
+
+_validate_env()
+
 # ---- utility checks ----------------------------------------------------------
 def _require_known(name: str):
     if name not in PRINTERS:


### PR DESCRIPTION
## Summary
- cross-check printer name sets across PRINTERS, SERIALS, LAN_KEYS, and TYPES during startup
- raise runtime errors when required fields are missing and log when types are absent

## Testing
- `python -m py_compile bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc87947654832fb056c48d69f78963

## Summary by Sourcery

Validate printer configuration at startup by ensuring environment variable consistency and halting execution on missing essential entries

New Features:
- Introduce _validate_env function to cross-check PRINTERS, SERIALS, LAN_KEYS, and TYPES at startup
- Log warnings for missing BAMBULAB_TYPES entries and default to X1C
- Raise runtime errors for any missing PRINTERS, SERIALS, or LAN_KEYS environment entries