### PR TITLE
Add test coverage for Bambu bridge helpers and API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ requests>=2.31,<3
 python-dateutil>=2.8.2,<3
 packaging>=23,<25
 swagger-ui-bundle==1.1.0
+pytest==8.2.2
+pytest-asyncio==0.23.6
+httpx==0.27.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def bridge(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    monkeypatch.setenv("BAMBULAB_PRINTERS", "p1@127.0.0.1")
+    monkeypatch.setenv("BAMBULAB_SERIALS", "p1=SERIAL1")
+    monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=LANKEY1")
+    monkeypatch.setenv("BAMBULAB_TYPES", "p1=X1C")
+    monkeypatch.setenv("BAMBULAB_API_KEY", "secret")
+    import bridge as module
+    importlib.reload(module)
+    return module
+
+
+@pytest.fixture
+def client(bridge, monkeypatch):
+    class FakeDev:
+        get_version_data = {"firmware": "1.0"}
+        push_all_data = {"state": "ok"}
+
+    class FakeClient:
+        def __init__(self, *, device_type, serial, host, local_mqtt, access_code, region, email, username, auth_token):
+            self.device_type = device_type
+            self.serial = serial
+            self.host = host
+            self.connected = False
+
+        def connect(self, callback=None):
+            self.connected = True
+
+        def get_device(self):
+            return FakeDev()
+
+        def start_print_from_url(self, *, gcode_url, thmf_url=None):
+            return {"started": gcode_url, "thmf": thmf_url}
+
+        def pause_print(self):
+            return {"paused": True}
+
+        def resume_print(self):
+            return {"resumed": True}
+
+        def stop_print(self):
+            return {"stopped": True}
+
+        def camera_mjpeg(self):
+            def gen():
+                yield b"frame"
+            return gen()
+
+    monkeypatch.setattr(bridge, "BambuClient", FakeClient)
+    with TestClient(bridge.app) as tc:
+        yield tc

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,21 @@
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+async def test_connect_error(monkeypatch, bridge):
+    class FailClient:
+        def __init__(self, *args, **kwargs):
+            self.host = kwargs["host"]
+            self.connected = False
+
+        def connect(self, callback=None):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(bridge, "BambuClient", FailClient)
+    with pytest.raises(HTTPException) as excinfo:
+        await bridge._connect("p1")
+    assert excinfo.value.status_code == 502
+    _, errors = await bridge.state.snapshot()
+    assert "p1" in errors
+    assert "RuntimeError" in errors["p1"]

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_pairs(monkeypatch, bridge):
+    monkeypatch.setenv("TEST_PAIRS", "a@1;b@2")
+    assert bridge._pairs("TEST_PAIRS") == {"a": "1", "b": "2"}
+
+
+def test_kv(monkeypatch, bridge):
+    monkeypatch.setenv("TEST_KV", "a=1;b=2")
+    assert bridge._kv("TEST_KV") == {"a": "1", "b": "2"}
+
+
+def test_validate_env_missing(bridge, monkeypatch):
+    monkeypatch.setattr(bridge, "PRINTERS", {"p1": "h"})
+    monkeypatch.setattr(bridge, "SERIALS", {})
+    monkeypatch.setattr(bridge, "LAN_KEYS", {"p1": "k"})
+    with pytest.raises(RuntimeError):
+        bridge._validate_env()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,42 @@
+from fastapi import HTTPException
+
+
+def test_health_and_printers(client):
+    res = client.get("/healthz")
+    assert res.status_code == 200
+    assert res.json()["printers"] == ["p1"]
+
+    res = client.get("/api/printers")
+    assert res.status_code == 200
+    data = res.json()
+    assert data[0]["name"] == "p1"
+    assert data[0]["connected"] is False
+
+
+def test_connect_status_and_actions(client):
+    headers = {"X-API-Key": "secret"}
+
+    res = client.post("/api/p1/connect", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+
+    res = client.get("/api/p1/status")
+    assert res.status_code == 200
+    assert res.json()["connected"] is True
+
+    res = client.post(
+        "/api/p1/print",
+        json={"gcode_url": "http://example.com/file.gcode"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert res.json()["started"] == "http://example.com/file.gcode"
+
+    assert client.post("/api/p1/pause", headers=headers).json()["paused"] is True
+    assert client.post("/api/p1/resume", headers=headers).json()["resumed"] is True
+    assert client.post("/api/p1/stop", headers=headers).json()["stopped"] is True
+
+
+def test_protected_route_requires_key(client):
+    res = client.post("/api/p1/connect")
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- include pytest, pytest-asyncio, and httpx in requirements
- add fixtures and tests for env parsing helpers
- cover _connect error handling with mocked BambuClient
- exercise key FastAPI routes and API-key protection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc8ae71038832f8867a56fb0910803

## Summary by Sourcery

Add pytest-based test suite for Bambu bridge including environment helper tests, API route tests, and error handling coverage

Bug Fixes:
- Handle BambuClient connect failures by returning HTTP 502 and logging error details

Build:
- Add pytest, pytest-asyncio, and httpx to project requirements

Tests:
- Introduce fixtures and fake client for testing with TestClient
- Add tests for environment parsing helpers (pairs, key-value parsing, and validation)
- Cover FastAPI routes including health, printer listing, connect, print, pause, resume, stop, and API-key protection
- Add asynchronous test for _connect error handling to raise HTTPException and record errors in state