### PR TITLE
Add configurable log level via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). T
    - `BAMBULAB_PRINTERS`
    - `BAMBULAB_SERIALS`
    - `BAMBULAB_LAN_KEYS`
-   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_API_KEY`
+   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_API_KEY`, `BAMBULAB_LOG_LEVEL`
      - `BAMBULAB_ALLOW_ORIGINS` defaults to only `http://localhost` and `http://127.0.0.1`
      - set `BAMBULAB_API_KEY` to require the same value in the `X-API-Key` header on write endpoints
+     - `BAMBULAB_LOG_LEVEL` controls logging verbosity (default `INFO`)
 3. After the container starts, open `http://<server-ip>:8288/docs` for the web UI and API documentation.
 
 A standard [`Dockerfile`](Dockerfile) is also included if you wish to build the image yourself.

--- a/bridge.py
+++ b/bridge.py
@@ -458,8 +458,9 @@ async def camera(name: str):
 
 def main() -> None:
     """Run the FastAPI application with a basic logging configuration."""
+    level_name = os.getenv("BAMBULAB_LOG_LEVEL", "INFO").upper()
     logging.basicConfig(
-        level=logging.INFO,
+        level=getattr(logging, level_name, logging.INFO),
         format="%(levelname)s:%(name)s:%(message)s",
     )
     import uvicorn


### PR DESCRIPTION
## Summary
- allow configuring logging verbosity via `BAMBULAB_LOG_LEVEL` environment variable
- document `BAMBULAB_LOG_LEVEL` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc8fb2efc8832fa2f1956521bd58f2