### PR TITLE
Add disconnect API endpoint and tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,9 @@ def client(bridge, monkeypatch):
                 yield b"frame"
             return gen()
 
+        def disconnect(self):
+            self.connected = False
+
     monkeypatch.setattr(bridge, "BambuClient", FakeClient)
     with TestClient(bridge.app) as tc:
         yield tc

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -40,3 +40,18 @@ def test_connect_status_and_actions(client):
 def test_protected_route_requires_key(client):
     res = client.post("/api/p1/connect")
     assert res.status_code == 403
+
+
+def test_disconnect(client):
+    headers = {"X-API-Key": "secret"}
+
+    assert client.post("/api/p1/connect", headers=headers).status_code == 200
+    res = client.post("/api/p1/disconnect", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["ok"] is True
+
+    data = client.get("/api/printers").json()
+    assert data[0]["connected"] is False
+
+    res = client.post("/api/p1/disconnect", headers=headers)
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- add API endpoint to disconnect printers and clear state
- test disconnect behavior with fake client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9063640c832fa0725ccd4e70bf93