### PR TITLE
chore: expand dockerignore entries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
 .DS_Store
 __pycache__/
+tests/
+*.pyc
+.pytest_cache/
+README.md


### PR DESCRIPTION
## Summary
- ignore tests, Python cache files, and docs in Docker build context

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9492d574832fb99c88b0ffd80232