### PR TITLE
Add CI workflow for tests and linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import importlib
-import os
 import sys
 from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,3 @@
-from fastapi import HTTPException
-
-
 def test_health_and_printers(client):
     res = client.get("/healthz")
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint and test on pushes and pull requests
- remove unused imports from tests for lint compatibility

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc959d14fc832f99783e51441d1379

## Summary by Sourcery

Add a CI workflow for linting and testing using GitHub Actions and clean up tests by removing unused imports.

Enhancements:
- Remove unused imports from test files to satisfy linting rules.

CI:
- Add GitHub Actions workflow to run lint checks and tests on push and pull request events.