### PR TITLE
Add camera stream test

### DIFF
--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,18 @@
+def test_camera_stream(client, monkeypatch):
+    from bridge import BambuClient
+
+    chunks = [b"chunk1", b"chunk2"]
+
+    def fake_camera_mjpeg(self):
+        def gen():
+            for c in chunks:
+                yield c
+        return gen()
+
+    monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
+
+    headers = {"X-API-Key": "secret"}
+    with client.stream("GET", "/api/p1/camera", headers=headers) as res:
+        assert res.status_code == 200
+        data = list(res.iter_bytes())
+    assert b"".join(data) == b"".join(chunks)


### PR DESCRIPTION
## Summary
- add test for `/api/{name}/camera` endpoint verifying streaming bytes

## Testing
- `pytest tests/test_camera.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc96b3ea28832f97520868f4d111e2