### PR TITLE
chore: separate dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.12-slim
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1 PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONPATH=/app
 WORKDIR /app
+# Install runtime dependencies only
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY bridge.py .
 RUN useradd -u 10001 -m appuser
 USER appuser

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ curl -X POST http://<server-ip>:8288/api/<printer>/print \
 
 `gcode_url` is required; `thmf_url` may be omitted.
 
+## Development
+
+Install the development dependencies to run the test suite:
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest==8.2.2
+pytest-asyncio==0.23.6
+httpx==0.27.2
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,3 @@ requests>=2.31,<3
 python-dateutil>=2.8.2,<3
 packaging>=23,<25
 swagger-ui-bundle==1.1.0
-pytest==8.2.2
-pytest-asyncio==0.23.6
-httpx==0.27.2


### PR DESCRIPTION
## Summary
- move pytest, pytest-asyncio, and httpx into requirements-dev.txt
- document installing dev dependencies for running tests
- Dockerfile installs only runtime requirements

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9993c8c8832fa85981bb51c6da92