### PR TITLE
Add per-printer connection locks

### DIFF
--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from fastapi import HTTPException
 
@@ -19,3 +20,31 @@ async def test_connect_error(monkeypatch, state_module):
     _, errors = await state_module.state.snapshot()
     assert "p1" in errors
     assert "RuntimeError" in errors["p1"]
+
+
+@pytest.mark.asyncio
+async def test_connect_lock(monkeypatch, state_module):
+    calls = 0
+
+    class SlowClient:
+        def __init__(self, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            self.host = kwargs["host"]
+            self.connected = False
+
+        def connect(self, callback=None):
+            async def delayed():
+                await asyncio.sleep(0.1)
+                self.connected = True
+            asyncio.create_task(delayed())
+
+    monkeypatch.setattr(state_module, "BambuClient", SlowClient)
+
+    c1, c2 = await asyncio.gather(
+        state_module._connect("p1"),
+        state_module._connect("p1"),
+    )
+
+    assert calls == 1
+    assert c1 is c2


### PR DESCRIPTION
## Summary
- Maintain an asyncio.Lock per printer to guard connection creation
- Ensure `_connect` uses the printer-specific lock and stores client before release
- Add regression test to verify only one client is created when connecting concurrently

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9a4fbe0c832fab4d1f4743302257