### PR TITLE
Run BambuClient connect in thread

### DIFF
--- a/state.py
+++ b/state.py
@@ -112,7 +112,7 @@ async def _connect(name: str, raise_http: bool = True) -> BambuClient:
                 username=USERNAME,
                 auth_token=AUTH_TOKEN,
             )
-            c.connect(callback=lambda evt: None)
+            await asyncio.to_thread(c.connect, callback=lambda evt: None)
 
             for _ in range(50):
                 if c.connected:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import pytest
 from fastapi import HTTPException
 
@@ -34,10 +35,8 @@ async def test_connect_lock(monkeypatch, state_module):
             self.connected = False
 
         def connect(self, callback=None):
-            async def delayed():
-                await asyncio.sleep(0.1)
-                self.connected = True
-            asyncio.create_task(delayed())
+            time.sleep(0.1)
+            self.connected = True
 
     monkeypatch.setattr(state_module, "BambuClient", SlowClient)
 


### PR DESCRIPTION
## Summary
- use `asyncio.to_thread` to run BambuClient.connect off the event loop
- update tests to model blocking connection call

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9ca38e0c832fb3fbea6c9a04dcc1