### PR TITLE
Validate environment at startup

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -8,6 +8,7 @@ import os
 import uvicorn
 
 from api import app
+import config
 
 
 def main() -> None:
@@ -16,6 +17,7 @@ def main() -> None:
         level=getattr(logging, level_name, logging.INFO),
         format="%(levelname)s:%(name)s:%(message)s",
     )
+    config._validate_env()
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))
 
 

--- a/config.py
+++ b/config.py
@@ -74,6 +74,3 @@ def _validate_env() -> None:
         raise RuntimeError(
             "Printer configuration incomplete; check environment variables"
         )
-
-
-_validate_env()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def cfg(monkeypatch):
     monkeypatch.setenv("BAMBULAB_API_KEY", "secret")
     import config
     importlib.reload(config)
+    config._validate_env()
     return config
 
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -19,6 +19,7 @@ def api_autoconnect(monkeypatch):
     import state
     import api
     importlib.reload(config)
+    config._validate_env()
     importlib.reload(state)
     importlib.reload(api)
     return state, api


### PR DESCRIPTION
## Summary
- Remove automatic environment validation from `config` import
- Validate environment in `bridge.main` before launching Uvicorn
- Explicitly run `_validate_env()` in test fixtures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9d29c3bc832fb2e97e214763d25a

## Summary by Sourcery

Move environment validation from module import to application startup and update tests to run validation explicitly

Enhancements:
- Remove automatic environment validation on config import
- Validate environment explicitly in bridge.main before launching Uvicorn

Tests:
- Invoke config._validate_env() in test fixtures and lifespan tests to ensure explicit environment validation