### PR TITLE
Warn on malformed config segments

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,6 +17,8 @@ def _pairs(env: str) -> Dict[str, str]:
         if "@" in part:
             n, h = part.split("@", 1)
             out[n.strip()] = h.strip()
+        else:
+            log.warning("Invalid printer pair segment '%s'", part)
     return out
 
 
@@ -28,6 +30,8 @@ def _kv(env: str) -> Dict[str, str]:
         if "=" in part:
             k, v = part.split("=", 1)
             out[k.strip()] = v.strip()
+        else:
+            log.warning("Invalid key/value segment '%s'", part)
     return out
 
 

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 
@@ -9,6 +10,22 @@ def test_pairs(monkeypatch, cfg):
 def test_kv(monkeypatch, cfg):
     monkeypatch.setenv("TEST_KV", "a=1;b=2")
     assert cfg._kv("TEST_KV") == {"a": "1", "b": "2"}
+
+
+def test_pairs_warn(monkeypatch, cfg, caplog):
+    monkeypatch.setenv("TEST_PAIRS", "a@1;bad;b@2;oops")
+    with caplog.at_level(logging.WARNING):
+        assert cfg._pairs("TEST_PAIRS") == {"a": "1", "b": "2"}
+    assert "bad" in caplog.text
+    assert "oops" in caplog.text
+
+
+def test_kv_warn(monkeypatch, cfg, caplog):
+    monkeypatch.setenv("TEST_KV", "a=1;bad;b=2;oops")
+    with caplog.at_level(logging.WARNING):
+        assert cfg._kv("TEST_KV") == {"a": "1", "b": "2"}
+    assert "bad" in caplog.text
+    assert "oops" in caplog.text
 
 
 def test_validate_env_missing(cfg, monkeypatch):


### PR DESCRIPTION
## Summary
- log warnings for malformed `name@host` or `key=value` segments in environment variables
- test warning behavior for `_pairs` and `_kv`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca0f549ac832f8236b9b51d821c7b