### PR TITLE
Copy all Python modules and verify presence before running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ WORKDIR /app
 # Install runtime dependencies only
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY bridge.py .
+# Copy all Python modules into the container
+COPY *.py .
 RUN useradd -u 10001 -m appuser
 USER appuser
 EXPOSE 8088
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=5 \
   CMD python - <<'PY'\nimport urllib.request; urllib.request.urlopen('http://127.0.0.1:8088/healthz', timeout=3)\nPY
-CMD ["python", "-m", "uvicorn", "bridge:app", "--host", "0.0.0.0", "--port", "8088"]
+# Ensure required modules exist before launching Uvicorn
+CMD ["sh", "-c", "test -f api.py && test -f config.py && test -f state.py && exec python -m uvicorn bridge:app --host 0.0.0.0 --port 8088"]


### PR DESCRIPTION
## Summary
- Copy all Python modules into the container
- Ensure required modules are present before launching Uvicorn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca33464ac832f937817b336e41423