### PR TITLE
Handle async connect and configurable waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). T
    - `BAMBULAB_PRINTERS`
    - `BAMBULAB_SERIALS`
    - `BAMBULAB_LAN_KEYS`
-   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_API_KEY`, `BAMBULAB_LOG_LEVEL`
+   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_API_KEY`, `BAMBULAB_LOG_LEVEL`, `BAMBULAB_CONNECT_INTERVAL`, `BAMBULAB_CONNECT_TIMEOUT`
      - `BAMBULAB_ALLOW_ORIGINS` defaults to only `http://localhost` and `http://127.0.0.1`
      - set `BAMBULAB_API_KEY` to require the same value in the `X-API-Key` header on write endpoints
      - `BAMBULAB_LOG_LEVEL` controls logging verbosity (default `INFO`)
+     - `BAMBULAB_CONNECT_INTERVAL` seconds between post-connect status checks (default `0.1`)
+     - `BAMBULAB_CONNECT_TIMEOUT` total seconds to wait for connection (default `5`)
 3. After the container starts, open `http://<server-ip>:8288/docs` for the web UI and API documentation.
 
 A standard [`Dockerfile`](Dockerfile) is also included if you wish to build the image yourself.

--- a/bambubridge.xml
+++ b/bambubridge.xml
@@ -34,6 +34,8 @@
   <Config Name="BAMBULAB_TYPES" Target="BAMBULAB_TYPES" Default="babu=X1C" Mode="env" Description="(optional) name=model (X1C/P1S/A1...)" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="BAMBULAB_REGION" Target="BAMBULAB_REGION" Default="US" Mode="env" Description="Region for pybambu ctor" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="BAMBULAB_AUTOCONNECT" Target="BAMBULAB_AUTOCONNECT" Default="1" Mode="env" Description="1=autoconnect on startup; 0=lazy" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="BAMBULAB_CONNECT_INTERVAL" Target="BAMBULAB_CONNECT_INTERVAL" Default="0.1" Mode="env" Description="Seconds between connection status checks" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="BAMBULAB_CONNECT_TIMEOUT" Target="BAMBULAB_CONNECT_TIMEOUT" Default="5" Mode="env" Description="Total seconds to wait for connection" Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="PYTHONUNBUFFERED" Target="PYTHONUNBUFFERED" Default="1" Mode="env" Description="leave as 1" Type="Variable" Display="advanced" Required="false" Mask="false"/>
 
   <!-- Expose the host port in the UI -->

--- a/config.py
+++ b/config.py
@@ -51,6 +51,9 @@ AUTOCONNECT = os.getenv("BAMBULAB_AUTOCONNECT", "0").lower() in {
     "on",
 }
 
+CONNECT_INTERVAL = float(os.getenv("BAMBULAB_CONNECT_INTERVAL", "0.1"))
+CONNECT_TIMEOUT = float(os.getenv("BAMBULAB_CONNECT_TIMEOUT", "5"))
+
 DEFAULT_ORIGINS = ["http://localhost", "http://127.0.0.1"]
 ALLOW_ORIGINS = [
     o.strip() for o in os.getenv("BAMBULAB_ALLOW_ORIGINS", "").split(",") if o.strip()


### PR DESCRIPTION
## Summary
- support `BambuClient.connect` being a coroutine and await it directly
- make post-connect polling interval and timeout configurable via `BAMBULAB_CONNECT_INTERVAL` and `BAMBULAB_CONNECT_TIMEOUT`
- document new environment variables and update Docker template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bca3e843d8832f91c4f2fb4a6f857d

## Summary by Sourcery

Support asynchronous BambuClient.connect coroutines and allow customizing post-connect polling interval and timeout via environment variables; update documentation and tests accordingly.

New Features:
- Allow BambuClient.connect to be an async coroutine and await it directly

Enhancements:
- Make post-connect polling interval and timeout configurable via BAMBULAB_CONNECT_INTERVAL and BAMBULAB_CONNECT_TIMEOUT
- Detect and handle coroutine or sync connect methods in _connect before polling

Documentation:
- Document BAMBULAB_CONNECT_INTERVAL and BAMBULAB_CONNECT_TIMEOUT in README and Docker template

Tests:
- Add tests for async connect handling and configurable timeout behavior