### PR TITLE
Handle async camera generators in camera endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ curl -X POST http://<server-ip>:8288/api/<printer>/print \
 
 `gcode_url` is required; `thmf_url` may be omitted.
 
+### Camera streaming
+
+To stream live MJPEG from a printer, send a `GET` request to
+`/api/{name}/camera`.  The underlying `pybambu` client may expose
+`camera_mjpeg` as either a synchronous or asynchronous function returning a
+generator.  `bambubridge` detects both forms and will await an async
+implementation automatically.
+
 ## Development
 
 Install the development dependencies to run the test suite:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,13 +1,24 @@
-def test_camera_stream(client, monkeypatch):
+import pytest
+
+
+@pytest.mark.parametrize("async_impl", [False, True])
+def test_camera_stream(client, monkeypatch, async_impl):
     from state import BambuClient
 
     chunks = [b"chunk1", b"chunk2"]
 
-    def fake_camera_mjpeg(self):
-        def gen():
-            for c in chunks:
-                yield c
-        return gen()
+    if async_impl:
+        async def fake_camera_mjpeg(self):
+            async def gen():
+                for c in chunks:
+                    yield c
+            return gen()
+    else:
+        def fake_camera_mjpeg(self):
+            def gen():
+                for c in chunks:
+                    yield c
+            return gen()
 
     monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
 


### PR DESCRIPTION
## Summary
- await camera_mjpeg functions returning awaitables
- document camera streaming endpoint and support for sync/async implementations
- test both synchronous and asynchronous camera_mjpeg generators

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bca5658b20832f9c7987b6fe03ddb0