### PR TITLE
Require API key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FastAPI wrapper for Bambu Lab printers exposed over the local network via [pybambu](https://pypi.org/project/pybambu/).
 
+**Configuration requires setting an API key via the `BAMBULAB_API_KEY` environment variable.**
+
 ## Unraid Docker
 
 An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). To install:
@@ -11,9 +13,9 @@ An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). T
    - `BAMBULAB_PRINTERS`
    - `BAMBULAB_SERIALS`
    - `BAMBULAB_LAN_KEYS`
-   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_API_KEY`, `BAMBULAB_LOG_LEVEL`, `BAMBULAB_CONNECT_INTERVAL`, `BAMBULAB_CONNECT_TIMEOUT`
+   - `BAMBULAB_API_KEY` (value clients must supply in the `X-API-Key` header)
+   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_LOG_LEVEL`, `BAMBULAB_CONNECT_INTERVAL`, `BAMBULAB_CONNECT_TIMEOUT`
      - `BAMBULAB_ALLOW_ORIGINS` defaults to only `http://localhost` and `http://127.0.0.1`
-     - set `BAMBULAB_API_KEY` to require the same value in the `X-API-Key` header on write endpoints
      - `BAMBULAB_LOG_LEVEL` controls logging verbosity (default `INFO`)
      - `BAMBULAB_CONNECT_INTERVAL` seconds between post-connect status checks (default `0.1`)
      - `BAMBULAB_CONNECT_TIMEOUT` total seconds to wait for connection (default `5`)
@@ -22,6 +24,8 @@ An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). T
 A standard [`Dockerfile`](Dockerfile) is also included if you wish to build the image yourself.
 
 ## API
+
+All write endpoints require an `X-API-Key` header matching the `BAMBULAB_API_KEY` value.
 
 To start a print job, POST to `/api/{name}/print` with a JSON body matching the
 `JobRequest` model:

--- a/api.py
+++ b/api.py
@@ -91,7 +91,9 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
 async def require_api_key(api_key: str = Security(api_key_header)) -> None:
-    if API_KEY and api_key != API_KEY:
+    if not API_KEY:
+        raise RuntimeError("API key not configured")
+    if api_key != API_KEY:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 
 

--- a/tests/test_api_key_required.py
+++ b/tests/test_api_key_required.py
@@ -1,0 +1,19 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_missing(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    monkeypatch.delenv("BAMBULAB_API_KEY", raising=False)
+    import config
+    importlib.reload(config)
+    import api
+    importlib.reload(api)
+
+    with pytest.raises(RuntimeError):
+        await api.require_api_key("secret")
+


### PR DESCRIPTION
## Summary
- error when `BAMBULAB_API_KEY` is unset rather than skipping auth checks
- document mandatory API key and header usage
- cover missing API key scenario with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bca9bb65b0832faef560c27d95688a

## Summary by Sourcery

Enforce mandatory API key configuration by raising an error when BAMBULAB_API_KEY is unset, update the documentation to require the API key and header usage, and add tests for missing API key scenarios.

Bug Fixes:
- Raise a RuntimeError if BAMBULAB_API_KEY is not set instead of bypassing authentication checks

Enhancements:
- Require the X-API-Key header to match BAMBULAB_API_KEY on write endpoints

Documentation:
- Document that setting BAMBULAB_API_KEY is mandatory and detail X-API-Key header usage in the README

Tests:
- Add test to ensure missing API key configuration raises a RuntimeError