### PR TITLE
test: use monkeypatch syspath in api_autoconnect

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,5 +1,4 @@
 import importlib
-import sys
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -9,7 +8,7 @@ import pytest
 
 @pytest.fixture
 def api_autoconnect(monkeypatch):
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parent.parent))
     monkeypatch.setenv("BAMBULAB_PRINTERS", "p1@127.0.0.1")
     monkeypatch.setenv("BAMBULAB_SERIALS", "p1=SERIAL1")
     monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=LANKEY1")


### PR DESCRIPTION
## Summary
- use `monkeypatch.syspath_prepend` instead of `sys.path.insert` in the `api_autoconnect` fixture

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcaaace10c832f8cf3c2a4af67bd4a

## Summary by Sourcery

Tests:
- Replace sys.path.insert with monkeypatch.syspath_prepend in the api_autoconnect fixture