### PR TITLE
Handle missing API key config

### DIFF
--- a/api.py
+++ b/api.py
@@ -99,7 +99,7 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 async def require_api_key(api_key: str = Security(api_key_header)) -> None:
     if not API_KEY:
-        raise RuntimeError("API key not configured")
+        raise HTTPException(status_code=500, detail="API key not configured")
     if api_key != API_KEY:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 

--- a/tests/test_api_key_required.py
+++ b/tests/test_api_key_required.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 
 
 @pytest.mark.asyncio
@@ -14,6 +15,8 @@ async def test_require_api_key_missing(monkeypatch):
     import api
     importlib.reload(api)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(HTTPException) as excinfo:
         await api.require_api_key("secret")
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "API key not configured"
 


### PR DESCRIPTION
## Summary
- return HTTP 500 if API key is not configured
- test the missing API key error response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcaf297df0832fb8045ffd43edc7be