### PR TITLE
Handle missing asyncio task in RLock

### DIFF
--- a/state.py
+++ b/state.py
@@ -41,7 +41,12 @@ class _RLock:
         self._count = 0
 
     async def acquire(self) -> None:
-        current = asyncio.current_task()
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:
+            current = None
+        if current is None:
+            raise RuntimeError("RLock used outside running event loop")
         if self._owner is current:
             self._count += 1
             return
@@ -50,7 +55,12 @@ class _RLock:
         self._count = 1
 
     def release(self) -> None:
-        current = asyncio.current_task()
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:
+            current = None
+        if current is None:
+            raise RuntimeError("RLock used outside running event loop")
         if self._owner is not current:
             raise RuntimeError("RLock release by non-owner")
         self._count -= 1

--- a/tests/test_rlock.py
+++ b/tests/test_rlock.py
@@ -1,0 +1,24 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from state import _RLock
+
+
+@pytest.mark.asyncio
+async def test_rlock_acquire_without_task(monkeypatch):
+    lock = _RLock()
+    monkeypatch.setattr(asyncio, "current_task", lambda loop=None: None)
+    with pytest.raises(RuntimeError, match="RLock used outside running event loop"):
+        await lock.acquire()
+
+
+def test_rlock_release_without_task(monkeypatch):
+    lock = _RLock()
+    monkeypatch.setattr(asyncio, "current_task", lambda loop=None: None)
+    with pytest.raises(RuntimeError, match="RLock used outside running event loop"):
+        lock.release()


### PR DESCRIPTION
## Summary
- guard `_RLock.acquire` and `release` against use outside of a running event loop
- test `_RLock` error when no current task exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcafb68b08832f9570d44a2ab257ce

## Summary by Sourcery

Guard `_RLock.acquire` and `release` to raise a RuntimeError when called outside of a running asyncio event loop and add corresponding tests.

Bug Fixes:
- Raise RuntimeError when `_RLock.acquire` or `release` is called with no current asyncio task

Tests:
- Add tests to verify error is raised for `_RLock.acquire` and `release` when `asyncio.current_task()` returns None