### PR TITLE
Handle callable camera_mjpeg generators

### DIFF
--- a/api.py
+++ b/api.py
@@ -325,7 +325,7 @@ async def camera(name: str):
 
     try:
         candidate = gen
-        if inspect.isfunction(gen) or inspect.ismethod(gen):
+        if callable(gen):
             candidate = gen()
             if inspect.isawaitable(candidate):
                 candidate = await candidate

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,26 +1,37 @@
 import pytest
 
 
-@pytest.mark.parametrize("async_impl", [False, True])
-def test_camera_stream(client, monkeypatch, async_impl):
+@pytest.mark.parametrize("impl", ["sync", "async", "callable"])
+def test_camera_stream(client, monkeypatch, impl):
     from state import BambuClient
 
     chunks = [b"chunk1", b"chunk2"]
 
-    if async_impl:
+    if impl == "async":
         async def fake_camera_mjpeg(self):
             async def gen():
                 for c in chunks:
                     yield c
             return gen()
-    else:
+
+        monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
+    elif impl == "sync":
         def fake_camera_mjpeg(self):
             def gen():
                 for c in chunks:
                     yield c
             return gen()
 
-    monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
+        monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
+    else:
+        class FakeCameraMjpeg:
+            def __call__(self):
+                def gen():
+                    for c in chunks:
+                        yield c
+                return gen()
+
+        monkeypatch.setattr(BambuClient, "camera_mjpeg", FakeCameraMjpeg())
 
     headers = {"X-API-Key": "secret"}
     with client.stream("GET", "/api/p1/camera", headers=headers) as res:


### PR DESCRIPTION
## Summary
- allow any callable to provide camera mjpeg stream
- test camera streaming with callable object implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcb07c27f4832f9d9f8ff38b87203d