### PR TITLE
Add runtime dependencies to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,17 @@ description = "FastAPI application for Bambu LAN bridge."
 readme = "README.md"
 requires-python = ">=3.10"
 
+[project.dependencies]
+fastapi = "==0.116.1"
+starlette = "==0.47.3"
+uvicorn = { version = "==0.30.6", extras = ["standard"] }
+pybambu = "==1.0.1"
+paho-mqtt = "<2"
+requests = ">=2.31,<3"
+python-dateutil = ">=2.8.2,<3"
+packaging = ">=23,<25"
+swagger-ui-bundle = "==1.1.0"
+
 [tool.setuptools]
 py-modules = ["api", "bridge", "config", "state", "__init__"]
 


### PR DESCRIPTION
## Summary
- declare runtime dependencies in `pyproject.toml` with pinned versions matching `requirements.txt`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1324e78832fa25eade2379bbf9b