### PR TITLE
Handle invalid connect timing env vars

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,21 @@ def _kv(env: str) -> Dict[str, str]:
     return out
 
 
+def _get_float(env: str, default: str) -> float:
+    """Return a float from ``env`` or ``default`` with error handling."""
+    raw = os.getenv(env, default)
+    try:
+        return float(raw)
+    except ValueError:
+        log.error("Invalid %s value %r; using default %s", env, raw, default)
+        try:
+            return float(default)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Invalid default for {env}: {default}"
+            ) from exc
+
+
 PRINTERS = _pairs("BAMBULAB_PRINTERS")
 SERIALS = _kv("BAMBULAB_SERIALS")
 LAN_KEYS = _kv("BAMBULAB_LAN_KEYS")
@@ -51,8 +66,8 @@ AUTOCONNECT = os.getenv("BAMBULAB_AUTOCONNECT", "0").lower() in {
     "on",
 }
 
-CONNECT_INTERVAL = float(os.getenv("BAMBULAB_CONNECT_INTERVAL", "0.1"))
-CONNECT_TIMEOUT = float(os.getenv("BAMBULAB_CONNECT_TIMEOUT", "5"))
+CONNECT_INTERVAL = _get_float("BAMBULAB_CONNECT_INTERVAL", "0.1")
+CONNECT_TIMEOUT = _get_float("BAMBULAB_CONNECT_TIMEOUT", "5")
 
 DEFAULT_ORIGINS = ["http://localhost", "http://127.0.0.1"]
 ALLOW_ORIGINS = [

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -28,6 +28,25 @@ def test_kv_warn(monkeypatch, cfg, caplog):
     assert "oops" in caplog.text
 
 
+def test_get_float(monkeypatch, cfg):
+    monkeypatch.setenv("TEST_FLOAT", "1.5")
+    assert cfg._get_float("TEST_FLOAT", "2") == 1.5
+
+
+def test_get_float_fallback(monkeypatch, cfg, caplog):
+    monkeypatch.setenv("TEST_FLOAT", "bad")
+    with caplog.at_level(logging.ERROR):
+        assert cfg._get_float("TEST_FLOAT", "2") == 2.0
+    assert "Invalid TEST_FLOAT value" in caplog.text
+
+
+def test_get_float_default_invalid(monkeypatch, cfg):
+    monkeypatch.setenv("TEST_FLOAT", "bad")
+    with pytest.raises(RuntimeError) as exc:
+        cfg._get_float("TEST_FLOAT", "also-bad")
+    assert "Invalid default for TEST_FLOAT" in str(exc.value)
+
+
 def test_validate_env_missing(cfg, monkeypatch):
     monkeypatch.setattr(cfg, "PRINTERS", {"p1": "h"})
     monkeypatch.setattr(cfg, "SERIALS", {})


### PR DESCRIPTION
## Summary
- add `_get_float` helper to safely parse connect interval and timeout
- log invalid environment values and fall back to defaults
- cover float parsing with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1b49bc0832fbb3862d7f8a0864c

## Summary by Sourcery

Introduce a safe float parsing helper for environment variables and apply it to connect interval and timeout settings to handle invalid inputs gracefully

Enhancements:
- Add _get_float helper to safely parse float environment variables with error logging and fallback to defaults
- Replace direct float conversion for CONNECT_INTERVAL and CONNECT_TIMEOUT with the new helper

Tests:
- Add tests for valid, invalid, and default-invalid scenarios for the _get_float helper