### PR TITLE
Expose bambubridge CLI entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ python-dateutil = ">=2.8.2,<3"
 packaging = ">=23,<25"
 swagger-ui-bundle = "==1.1.0"
 
+[project.scripts]
+bambubridge = "bridge:main"
+
 [tool.setuptools]
 py-modules = ["api", "bridge", "config", "state", "__init__"]
 


### PR DESCRIPTION
## Summary
- add `bambubridge` console script entry to pyproject

## Testing
- `python -m pip install -e .` *(fails: `project.dependencies` must be array)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcb2db2c8c832f9378a8cb32eaed99