### PR TITLE
Warn on duplicate env entries

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,11 +12,16 @@ log = logging.getLogger("bambubridge")
 def _pairs(env: str) -> Dict[str, str]:
     """Parse "name@host;other@host2" strings into dicts."""
     out: Dict[str, str] = {}
+    seen: set[str] = set()
     raw = os.getenv(env, "")
     for part in filter(None, raw.split(";")):
         if "@" in part:
             n, h = part.split("@", 1)
-            out[n.strip()] = h.strip()
+            key = n.strip()
+            if key in seen:
+                log.warning("Duplicate %s entry for '%s'", env, key)
+            seen.add(key)
+            out[key] = h.strip()
         else:
             log.warning("Invalid printer pair segment '%s'", part)
     return out
@@ -25,11 +30,16 @@ def _pairs(env: str) -> Dict[str, str]:
 def _kv(env: str) -> Dict[str, str]:
     """Parse "key=value;other=value2" strings into dicts."""
     out: Dict[str, str] = {}
+    seen: set[str] = set()
     raw = os.getenv(env, "")
     for part in filter(None, raw.split(";")):
         if "=" in part:
             k, v = part.split("=", 1)
-            out[k.strip()] = v.strip()
+            key = k.strip()
+            if key in seen:
+                log.warning("Duplicate %s entry for '%s'", env, key)
+            seen.add(key)
+            out[key] = v.strip()
         else:
             log.warning("Invalid key/value segment '%s'", part)
     return out

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -28,6 +28,20 @@ def test_kv_warn(monkeypatch, cfg, caplog):
     assert "oops" in caplog.text
 
 
+def test_pairs_duplicate_warn(monkeypatch, cfg, caplog):
+    monkeypatch.setenv("TEST_DUP_PAIRS", "a@1;a@2")
+    with caplog.at_level(logging.WARNING):
+        assert cfg._pairs("TEST_DUP_PAIRS") == {"a": "2"}
+    assert "Duplicate TEST_DUP_PAIRS entry for 'a'" in caplog.text
+
+
+def test_kv_duplicate_warn(monkeypatch, cfg, caplog):
+    monkeypatch.setenv("TEST_DUP_KV", "a=1;a=2")
+    with caplog.at_level(logging.WARNING):
+        assert cfg._kv("TEST_DUP_KV") == {"a": "2"}
+    assert "Duplicate TEST_DUP_KV entry for 'a'" in caplog.text
+
+
 def test_get_float(monkeypatch, cfg):
     monkeypatch.setenv("TEST_FLOAT", "1.5")
     assert cfg._get_float("TEST_FLOAT", "2") == 1.5


### PR DESCRIPTION
## Summary
- warn and track duplicate keys in `_pairs`/`_kv` env parsers
- add tests ensuring duplicates emit warnings

## Testing
- `pytest tests/test_env_helpers.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcb36dd4a0832f821aece92bcbd253