### PR TITLE
Enforce API key presence at startup

### DIFF
--- a/api.py
+++ b/api.py
@@ -41,6 +41,8 @@ log = logging.getLogger("bambubridge")
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     config._validate_env()
+    if not API_KEY:
+        raise RuntimeError("API key not configured")
     if not AUTOCONNECT:
         log.info("startup: lazy mode (BAMBULAB_AUTOCONNECT not set)")
     else:
@@ -98,8 +100,6 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
 async def require_api_key(api_key: str = Security(api_key_header)) -> None:
-    if not API_KEY:
-        raise HTTPException(status_code=500, detail="API key not configured")
     if api_key != API_KEY:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 

--- a/tests/test_api_key_required.py
+++ b/tests/test_api_key_required.py
@@ -3,20 +3,25 @@ import sys
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 
-@pytest.mark.asyncio
-async def test_require_api_key_missing(monkeypatch):
+def test_startup_requires_api_key(monkeypatch):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
     monkeypatch.delenv("BAMBULAB_API_KEY", raising=False)
+    monkeypatch.setenv("BAMBULAB_PRINTERS", "p1@127.0.0.1")
+    monkeypatch.setenv("BAMBULAB_SERIALS", "p1=SERIAL1")
+    monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=LANKEY1")
+    monkeypatch.setenv("BAMBULAB_TYPES", "p1=X1C")
     import config
     importlib.reload(config)
+    import state
+    importlib.reload(state)
     import api
     importlib.reload(api)
 
-    with pytest.raises(HTTPException) as excinfo:
-        await api.require_api_key("secret")
-    assert excinfo.value.status_code == 500
-    assert excinfo.value.detail == "API key not configured"
+    with pytest.raises(RuntimeError) as excinfo:
+        with TestClient(api.app):
+            pass
+    assert str(excinfo.value) == "API key not configured"
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -14,6 +14,7 @@ def api_autoconnect(monkeypatch):
     monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=LANKEY1")
     monkeypatch.setenv("BAMBULAB_TYPES", "p1=X1C")
     monkeypatch.setenv("BAMBULAB_AUTOCONNECT", "1")
+    monkeypatch.setenv("BAMBULAB_API_KEY", "secret")
     import config
     import state
     import api


### PR DESCRIPTION
## Summary
- Ensure FastAPI lifespan fails without configured API key
- Simplify `require_api_key` to return 403 only
- Update tests for API key startup requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb5ae9a94832fb8b8e5aef59d55ad