### PR TITLE
Refactor print invocation helper and add API variant tests

### DIFF
--- a/tests/test_invoke_print.py
+++ b/tests/test_invoke_print.py
@@ -1,0 +1,43 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_invoke_print_accepts_url_kw(api_module):
+    """Function expects ``url`` keyword."""
+    def impl(*, url, thmf_url=None):
+        return {"url": url, "thmf_url": thmf_url}
+
+    res = await api_module._invoke_print(impl, "http://g", "http://t")
+    assert res["url"] == "http://g"
+    assert res["thmf_url"] == "http://t"
+
+
+@pytest.mark.asyncio
+async def test_invoke_print_accepts_positional(api_module):
+    """Function expects positional arguments."""
+    def impl(url, thmf_url=None):
+        return {"url": url, "thmf_url": thmf_url}
+
+    res = await api_module._invoke_print(impl, "http://g", "http://t")
+    assert res["url"] == "http://g"
+    assert res["thmf_url"] == "http://t"
+
+
+@pytest.mark.asyncio
+async def test_invoke_print_async(api_module):
+    """Asynchronous function expecting ``url`` keyword."""
+    async def impl(*, url, thmf_url=None):
+        return {"url": url, "thmf_url": thmf_url}
+
+    res = await api_module._invoke_print(impl, "http://g", None)
+    assert res["url"] == "http://g"
+    assert res["thmf_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_invoke_print_no_match(api_module):
+    """Unsupported function signatures raise ``TypeError``."""
+    def impl(a, b):
+        return {}
+
+    with pytest.raises(TypeError):
+        await api_module._invoke_print(impl, "http://g", None)


### PR DESCRIPTION
## Summary
- extract `_invoke_print` helper to normalize pybambu print signatures via iterative kwargs/args attempts
- use helper in `/api/{name}/print` to simplify nested try/except
- add unit tests covering url keyword, positional, async and failing signatures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb73a3c54832f90f1d67ed3ac050b