### PR TITLE
Use constant-time API key comparison

### DIFF
--- a/api.py
+++ b/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import inspect
+import secrets
 from contextlib import asynccontextmanager
 from typing import Dict, Any, Optional, Callable, AsyncGenerator, Generator
 
@@ -100,8 +101,12 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
 async def require_api_key(api_key: str = Security(api_key_header)) -> None:
-    if api_key != API_KEY:
-        raise HTTPException(status_code=403, detail="Invalid or missing API key")
+    if not api_key or not secrets.compare_digest(api_key, API_KEY):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing API key",
+            headers={"WWW-Authenticate": "API-Key"},
+        )
 
 
 # ---- Swagger UI assets served locally (no external CDN needed) ---------------

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -47,7 +47,7 @@ def test_connect_status_and_actions(client):
 
 def test_protected_route_requires_key(client):
     res = client.post("/api/p1/connect")
-    assert res.status_code == 403
+    assert res.status_code == 401
 
 
 def test_disconnect(client):


### PR DESCRIPTION
## Summary
- Use `secrets.compare_digest` for API key verification
- Return 401 with `WWW-Authenticate` header on invalid API key
- Update tests to expect unauthorized status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd863f81c832fad650618ac1fa2ad