### PR TITLE
Allow camera_mjpeg generator instances

### DIFF
--- a/api.py
+++ b/api.py
@@ -367,15 +367,13 @@ async def camera(name: str):
 
     c = await _connect(name)
     gen = getattr(c, "camera_mjpeg", None)
-    if not callable(gen):
+    if gen is None:
         raise HTTPException(501, "Camera MJPEG not available in this pybambu build")
 
     try:
-        candidate = gen
-        if callable(gen):
-            candidate = gen()
-            if inspect.isawaitable(candidate):
-                candidate = await candidate
+        candidate = gen() if callable(gen) else gen
+        if inspect.isawaitable(candidate):
+            candidate = await candidate
 
         if inspect.isasyncgen(candidate):
             async def astream() -> AsyncGenerator[bytes, None]:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.parametrize("impl", ["sync", "async", "callable"])
+@pytest.mark.parametrize("impl", ["sync", "async", "callable", "generator"])
 def test_camera_stream(client, monkeypatch, impl):
     from state import BambuClient
 
@@ -23,6 +23,11 @@ def test_camera_stream(client, monkeypatch, impl):
             return gen()
 
         monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
+    elif impl == "generator":
+        def gen():
+            for c in chunks:
+                yield c
+        monkeypatch.setattr(BambuClient, "camera_mjpeg", gen())
     else:
         class FakeCameraMjpeg:
             def __call__(self):
@@ -38,3 +43,16 @@ def test_camera_stream(client, monkeypatch, impl):
         assert res.status_code == 200
         data = list(res.iter_bytes())
     assert b"".join(data) == b"".join(chunks)
+
+
+def test_camera_stream_unsupported(client, monkeypatch):
+    from state import BambuClient
+
+    def fake_camera_mjpeg(self):
+        return "not-bytes"
+
+    monkeypatch.setattr(BambuClient, "camera_mjpeg", fake_camera_mjpeg)
+
+    headers = {"X-API-Key": "secret"}
+    res = client.get("/api/p1/camera", headers=headers)
+    assert res.status_code == 501


### PR DESCRIPTION
## Summary
- Support `camera_mjpeg` being an existing generator as well as a callable
- Add tests covering generator instances and unsupported types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcda212fd0832f819fe4baaed1ea1c