### PR TITLE
test: add camera stream error scenarios

### DIFF
--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -55,4 +55,14 @@ def test_camera_stream_unsupported(client, monkeypatch):
 
     headers = {"X-API-Key": "secret"}
     res = client.get("/api/p1/camera", headers=headers)
+    assert res.status_code in (501, 502)
+
+
+def test_camera_stream_missing(client, monkeypatch):
+    from state import BambuClient
+
+    monkeypatch.delattr(BambuClient, "camera_mjpeg", raising=False)
+
+    headers = {"X-API-Key": "secret"}
+    res = client.get("/api/p1/camera", headers=headers)
     assert res.status_code == 501


### PR DESCRIPTION
## Summary
- expand camera streaming tests with unsupported and missing camera implementations
- cover 501/502 responses when `camera_mjpeg` is invalid or absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d4222f0832fa8794ba90d567e00