### PR TITLE
Use bridge entrypoint and honor env-based port/logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-slim
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONPATH=/app \
+    BAMBULAB_LOG_LEVEL=INFO PORT=8088
 WORKDIR /app
 # Install runtime dependencies only
 COPY requirements.txt .
@@ -10,6 +11,6 @@ RUN useradd -u 10001 -m appuser
 USER appuser
 EXPOSE 8088
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=5 \
-  CMD python - <<'PY'\nimport urllib.request; urllib.request.urlopen('http://127.0.0.1:8088/healthz', timeout=3)\nPY
-# Ensure required modules exist before launching Uvicorn
-CMD ["sh", "-c", "test -f api.py && test -f config.py && test -f state.py && exec python -m uvicorn bridge:app --host 0.0.0.0 --port 8088"]
+  CMD python - <<'PY'\nimport os, urllib.request; urllib.request.urlopen(f"http://127.0.0.1:{os.getenv('PORT','8088')}/healthz", timeout=3)\nPY
+# Ensure required modules exist before launching the application
+CMD ["sh", "-c", "test -f api.py && test -f config.py && test -f state.py && exec python bridge.py"]

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). T
    - `BAMBULAB_SERIALS`
    - `BAMBULAB_LAN_KEYS`
    - `BAMBULAB_API_KEY` (value clients must supply in the `X-API-Key` header)
-   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_LOG_LEVEL`, `BAMBULAB_CONNECT_INTERVAL`, `BAMBULAB_CONNECT_TIMEOUT`, `BAMBULAB_EMAIL`, `BAMBULAB_USERNAME`, `BAMBULAB_AUTH_TOKEN`
+   - optional: `BAMBULAB_TYPES`, `BAMBULAB_REGION`, `BAMBULAB_AUTOCONNECT`, `BAMBULAB_ALLOW_ORIGINS`, `BAMBULAB_LOG_LEVEL`, `PORT`, `BAMBULAB_CONNECT_INTERVAL`, `BAMBULAB_CONNECT_TIMEOUT`, `BAMBULAB_EMAIL`, `BAMBULAB_USERNAME`, `BAMBULAB_AUTH_TOKEN`
      - `BAMBULAB_ALLOW_ORIGINS` defaults to only `http://localhost` and `http://127.0.0.1`
      - `BAMBULAB_LOG_LEVEL` controls logging verbosity (default `INFO`)
+     - `PORT` port for the API inside the container (default `8088`)
      - `BAMBULAB_CONNECT_INTERVAL` seconds between post-connect status checks (default `0.1`)
      - `BAMBULAB_CONNECT_TIMEOUT` total seconds to wait for connection (default `5`)
      - `BAMBULAB_EMAIL` email address for a Bambu Lab account
@@ -25,6 +26,8 @@ An Unraid Docker template is provided in [`bambubridge.xml`](bambubridge.xml). T
 3. After the container starts, open `http://<server-ip>:8288/docs` for the web UI and API documentation.
 
 A standard [`Dockerfile`](Dockerfile) is also included if you wish to build the image yourself.
+
+The Docker image launches `bridge.py`, which honors the `BAMBULAB_LOG_LEVEL` and `PORT` environment variables.
 
 ## API
 


### PR DESCRIPTION
## Summary
- run `bridge.py` in the Docker image so log level and port come from env vars
- make healthcheck and defaults respect `PORT` and `BAMBULAB_LOG_LEVEL`
- document the new `PORT` option and entrypoint in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd5f8684d8832fb837ba0f9d54cf24

## Summary by Sourcery

Use bridge.py as the Docker entrypoint and make port and logging configurable via environment variables

New Features:
- Support configuring the service port via the PORT environment variable
- Honor BAMBULAB_LOG_LEVEL environment variable for log verbosity in the Docker container

Enhancements:
- Switch the Docker entrypoint to launch bridge.py instead of invoking Uvicorn directly
- Update the healthcheck command to use the PORT environment variable

Build:
- Define default BAMBULAB_LOG_LEVEL and PORT environment variables in the Dockerfile

Documentation:
- Document the new PORT environment variable and its default value in the README
- Add note about the Docker image launching bridge.py to respect env-based configuration