### PR TITLE
Handle missing API key

### DIFF
--- a/api.py
+++ b/api.py
@@ -101,6 +101,11 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 
 async def require_api_key(api_key: str = Security(api_key_header)) -> None:
+    if API_KEY is None:
+        raise HTTPException(
+            status_code=500,
+            detail="API key not configured",
+        )
     if not api_key or not secrets.compare_digest(api_key, API_KEY):
         raise HTTPException(
             status_code=401,

--- a/tests/test_api_key_required.py
+++ b/tests/test_api_key_required.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 
@@ -24,4 +25,22 @@ def test_startup_requires_api_key(monkeypatch):
         with TestClient(api.app):
             pass
     assert str(excinfo.value) == "API key not configured"
+
+
+@pytest.mark.asyncio
+async def test_dependency_requires_configured_api_key(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    monkeypatch.delenv("BAMBULAB_API_KEY", raising=False)
+    monkeypatch.setenv("BAMBULAB_PRINTERS", "p1@127.0.0.1")
+    monkeypatch.setenv("BAMBULAB_SERIALS", "p1=SERIAL1")
+    monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=LANKEY1")
+    monkeypatch.setenv("BAMBULAB_TYPES", "p1=X1C")
+    import config
+    importlib.reload(config)
+    import api
+    importlib.reload(api)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await api.require_api_key(api_key="test")
+    assert excinfo.value.status_code == 500
 


### PR DESCRIPTION
## Summary
- Guard against `API_KEY` being `None` in `require_api_key`
- Add test covering missing API key in dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd62891870832f84889b344ece7050