### PR TITLE
Use signature to call print function

### DIFF
--- a/tests/test_invoke_print.py
+++ b/tests/test_invoke_print.py
@@ -41,3 +41,14 @@ async def test_invoke_print_no_match(api_module):
 
     with pytest.raises(TypeError):
         await api_module._invoke_print(impl, "http://g", None)
+
+
+@pytest.mark.asyncio
+async def test_invoke_print_propagates_inner_type_error(api_module):
+    """``TypeError`` raised inside ``fn`` is not swallowed."""
+
+    def impl(*, url, thmf_url=None):
+        raise TypeError("boom")
+
+    with pytest.raises(TypeError, match="boom"):
+        await api_module._invoke_print(impl, "http://g", None)


### PR DESCRIPTION
## Summary
- inspect function signatures to select argument names for `_invoke_print`
- propagate TypeErrors from inside print function
- add test for TypeError propagation in `_invoke_print`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd6342149c832fb0878b41575245d8