### PR TITLE
refactor: unify env parsing

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,40 +9,36 @@ from typing import Dict
 log = logging.getLogger("bambubridge")
 
 
-def _pairs(env: str) -> Dict[str, str]:
-    """Parse "name@host;other@host2" strings into dicts."""
+def _parse_env(env: str, sep: str, err: str) -> Dict[str, str]:
+    """Parse ``key{sep}value`` pairs from ``env`` separated by ``;``.
+
+    ``err`` is a format string used when an invalid segment is encountered.
+    """
+
     out: Dict[str, str] = {}
     seen: set[str] = set()
     raw = os.getenv(env, "")
     for part in filter(None, raw.split(";")):
-        if "@" in part:
-            n, h = part.split("@", 1)
-            key = n.strip()
-            if key in seen:
-                raise ValueError(f"Duplicate {env} entry for '{key}'")
-            seen.add(key)
-            out[key] = h.strip()
-        else:
-            log.warning("Invalid printer pair segment '%s'", part)
-    return out
-
-
-def _kv(env: str) -> Dict[str, str]:
-    """Parse "key=value;other=value2" strings into dicts."""
-    out: Dict[str, str] = {}
-    seen: set[str] = set()
-    raw = os.getenv(env, "")
-    for part in filter(None, raw.split(";")):
-        if "=" in part:
-            k, v = part.split("=", 1)
+        if sep in part:
+            k, v = part.split(sep, 1)
             key = k.strip()
             if key in seen:
                 raise ValueError(f"Duplicate {env} entry for '{key}'")
             seen.add(key)
             out[key] = v.strip()
         else:
-            log.warning("Invalid key/value segment '%s'", part)
+            log.warning(err, part)
     return out
+
+
+def _pairs(env: str) -> Dict[str, str]:
+    """Parse "name@host;other@host2" strings into dicts."""
+    return _parse_env(env, "@", "Invalid printer pair segment '%s'")
+
+
+def _kv(env: str) -> Dict[str, str]:
+    """Parse "key=value;other=value2" strings into dicts."""
+    return _parse_env(env, "=", "Invalid key/value segment '%s'")
 
 
 def _get_float(env: str, default: str) -> float:


### PR DESCRIPTION
## Summary
- introduce generic delimiter-based env parser
- reuse parser for printer and key/value helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd660eedfc832f9a209da3793f7aaa

## Summary by Sourcery

Unify environment variable parsing by introducing a generic delimiter-based parser and refactor existing _pairs and _kv functions to use it.

Enhancements:
- Introduce a generic _parse_env function to handle delimiter-based parsing of environment variables.
- Refactor _pairs and _kv to delegate parsing logic to the new _parse_env helper and reduce code duplication.