### PR TITLE
refactor: extract _pick helper

### DIFF
--- a/api.py
+++ b/api.py
@@ -34,6 +34,7 @@ from config import (
     AUTOCONNECT,
 )
 from state import state, _connect, _require_known, BambuClient
+from utils import _pick
 
 log = logging.getLogger("bambubridge")
 
@@ -148,13 +149,6 @@ except Exception as _e:  # pragma: no cover - optional dependency missing
 
 
 # ---- helpers -----------------------------------------------------------------
-
-def _pick(obj: Any, names: tuple[str, ...]) -> Optional[Callable]:
-    for n in names:
-        fn = getattr(obj, n, None)
-        if callable(fn):
-            return fn
-    return None
 
 
 async def _run_printer_action(

--- a/state.py
+++ b/state.py
@@ -25,6 +25,7 @@ from config import (
     CONNECT_INTERVAL,
     CONNECT_TIMEOUT,
 )
+from utils import _pick
 
 log = logging.getLogger("bambubridge")
 
@@ -115,11 +116,7 @@ async def _connect(
             return c
 
         if c:
-            try:
-                from api import _pick  # local import to avoid circular dependency
-            except Exception:  # pragma: no cover - import errors
-                _pick = lambda *_args: None  # type: ignore
-            fn = _pick(c, ("disconnect", "close")) if _pick else None
+            fn = _pick(c, ("disconnect", "close"))
             if fn:
                 try:
                     if inspect.iscoroutinefunction(fn):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,15 @@
+"""Utility helpers for bambubridge."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+
+def _pick(obj: Any, names: tuple[str, ...]) -> Optional[Callable]:
+    """Return the first callable attribute found on *obj* matching *names*."""
+    for n in names:
+        fn = getattr(obj, n, None)
+        if callable(fn):
+            return fn
+    return None
+


### PR DESCRIPTION
## Summary
- factor out `_pick` helper into new `utils` module
- reuse `_pick` in API and state modules and drop runtime import workaround

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd686a9cc0832fb5c842eb2908ba38

## Summary by Sourcery

Refactor code by extracting the `_pick` helper into a dedicated `utils` module and update all references to remove local definitions and import workarounds.

Enhancements:
- Factor out the `_pick` helper into a new `utils` module
- Update `api.py` and `state.py` to import and use `_pick` from `utils`
- Remove duplicate `_pick` definitions and circular import workarounds