### PR TITLE
Handle expected connection errors

### DIFF
--- a/state.py
+++ b/state.py
@@ -164,7 +164,7 @@ async def _connect(
             log.info("connected: %s@%s (%s)", name, host, serial)
             return c
 
-        except Exception as e:  # pragma: no cover - network failures
+        except (OSError, RuntimeError, asyncio.TimeoutError) as e:  # pragma: no cover - network failures
             detail = f"{type(e).__name__}: {e}"
             await state.set_error(name, detail)
             log.warning("connect(%s) failed: %s", name, detail)


### PR DESCRIPTION
## Summary
- Catch only known connection-related exceptions during printer connect
- Allow unexpected exceptions to propagate for easier debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd687307d8832f81fb9302297a44a0