### PR TITLE
Validate log level

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -12,10 +12,19 @@ from api import app
 
 def main() -> None:
     level_name = os.getenv("BAMBULAB_LOG_LEVEL", "INFO").upper()
-    logging.basicConfig(
-        level=getattr(logging, level_name, logging.INFO),
-        format="%(levelname)s:%(name)s:%(message)s",
-    )
+    if level_name not in logging._nameToLevel:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(levelname)s:%(name)s:%(message)s",
+        )
+        logging.warning(
+            "Invalid log level %s provided, falling back to INFO", level_name
+        )
+    else:
+        logging.basicConfig(
+            level=logging._nameToLevel[level_name],
+            format="%(levelname)s:%(name)s:%(message)s",
+        )
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))
 
 


### PR DESCRIPTION
## Summary
- handle invalid BAMBULAB_LOG_LEVEL values by warning and defaulting to INFO

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd69567334832fb4709c17fa69b83f

## Summary by Sourcery

Enhancements:
- Warn and fallback to INFO when an invalid log level is provided via BAMBULAB_LOG_LEVEL