### PR TITLE
Validate allowed origins from environment

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,10 +6,11 @@ progress.
 
 from __future__ import annotations
 
-import os
 import logging
+import os
 from threading import Lock
 from typing import Dict
+from urllib.parse import urlparse
 
 log = logging.getLogger("bambubridge")
 
@@ -83,9 +84,18 @@ CONNECT_INTERVAL = _get_float("BAMBULAB_CONNECT_INTERVAL", "0.1")
 CONNECT_TIMEOUT = _get_float("BAMBULAB_CONNECT_TIMEOUT", "5")
 
 DEFAULT_ORIGINS = ["http://localhost", "http://127.0.0.1"]
-ALLOW_ORIGINS = [
+ALLOW_ORIGINS_RAW = [
     o.strip() for o in os.getenv("BAMBULAB_ALLOW_ORIGINS", "").split(",") if o.strip()
-] or DEFAULT_ORIGINS
+]
+ALLOW_ORIGINS = []
+for origin in ALLOW_ORIGINS_RAW:
+    parsed = urlparse(origin)
+    if parsed.scheme in {"http", "https"} and parsed.netloc and not parsed.params and not parsed.query and not parsed.fragment:
+        ALLOW_ORIGINS.append(origin)
+    else:
+        log.warning("Ignoring invalid origin '%s'", origin)
+if not ALLOW_ORIGINS:
+    ALLOW_ORIGINS = DEFAULT_ORIGINS
 
 API_KEY = os.getenv("BAMBULAB_API_KEY")
 

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -92,3 +92,19 @@ def test_validate_env_duplicate(cfg, monkeypatch):
     with pytest.raises(RuntimeError) as exc:
         cfg._validate_env()
     assert "Duplicate BAMBULAB_PRINTERS entry for 'a'" in str(exc.value)
+
+
+def test_allow_origins_validation(monkeypatch, caplog):
+    monkeypatch.setenv(
+        "BAMBULAB_ALLOW_ORIGINS",
+        "http://good.com,not-a-url,https://ok.org,ftp://bad.com",
+    )
+    import importlib
+    import config
+
+    with caplog.at_level(logging.WARNING):
+        importlib.reload(config)
+
+    assert config.ALLOW_ORIGINS == ["http://good.com", "https://ok.org"]
+    assert "Ignoring invalid origin 'not-a-url'" in caplog.text
+    assert "Ignoring invalid origin 'ftp://bad.com'" in caplog.text


### PR DESCRIPTION
## Summary
- validate entries from `BAMBULAB_ALLOW_ORIGINS` using `urlparse`
- warn and ignore invalid origins instead of accepting blindly
- test that invalid origins are skipped and warnings are emitted

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd6a06cfd0832fab5630dc4ee0ea09