### PR TITLE
use public logging API for log level lookup

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -12,7 +12,8 @@ from api import app
 
 def main() -> None:
     level_name = os.getenv("BAMBULAB_LOG_LEVEL", "INFO").upper()
-    if level_name not in logging._nameToLevel:
+    level = getattr(logging, level_name, None)
+    if not isinstance(level, int):
         logging.basicConfig(
             level=logging.INFO,
             format="%(levelname)s:%(name)s:%(message)s",
@@ -22,7 +23,7 @@ def main() -> None:
         )
     else:
         logging.basicConfig(
-            level=logging._nameToLevel[level_name],
+            level=level,
             format="%(levelname)s:%(name)s:%(message)s",
         )
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))


### PR DESCRIPTION
## Summary
- avoid using private `logging._nameToLevel`; resolve levels via `getattr`
- retain fallback to INFO with warning for invalid levels

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdee65116c832faa3de1014d57d118