### PR TITLE
Add PrinterInfo model and update tests

### DIFF
--- a/api.py
+++ b/api.py
@@ -222,6 +222,16 @@ class JobRequest(BaseModel):
     thmf_url: Optional[HttpUrl] = None
 
 
+class PrinterInfo(BaseModel):
+    """Details about a configured printer."""
+
+    name: str
+    host: str
+    serial: Optional[str] = None
+    connected: bool
+    last_error: Optional[str] = None
+
+
 class StatusResult(BaseModel):
     """Standard response wrapper for status information."""
 
@@ -246,20 +256,20 @@ async def healthz() -> StatusResult:
 
 
 @app.get("/api/printers")
-async def list_printers():
+async def list_printers() -> list[PrinterInfo]:
     """List configured printers and their connection status."""
-    out = []
+    out: list[PrinterInfo] = []
     clients_snapshot, errors_snapshot = await state.snapshot()
     for n, host in PRINTERS.items():
         c = clients_snapshot.get(n)
         out.append(
-            {
-                "name": n,
-                "host": host,
-                "serial": SERIALS.get(n),
-                "connected": bool(c and getattr(c, "connected", False)),
-                "last_error": errors_snapshot.get(n),
-            }
+            PrinterInfo(
+                name=n,
+                host=host,
+                serial=SERIALS.get(n),
+                connected=bool(c and getattr(c, "connected", False)),
+                last_error=errors_snapshot.get(n),
+            )
         )
     return out
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -6,8 +6,12 @@ def test_health_and_printers(client):
     res = client.get("/api/printers")
     assert res.status_code == 200
     data = res.json()
-    assert data[0]["name"] == "p1"
-    assert data[0]["connected"] is False
+    printer = data[0]
+    assert printer["name"] == "p1"
+    assert printer["host"] == "127.0.0.1"
+    assert printer["serial"] == "SERIAL1"
+    assert printer["connected"] is False
+    assert printer["last_error"] is None
 
 
 def test_connect_status_and_actions(client):
@@ -61,7 +65,11 @@ def test_disconnect(client):
     assert data["result"]["name"] == "p1"
 
     data = client.get("/api/printers").json()
-    assert data[0]["connected"] is False
+    printer = data[0]
+    assert printer["connected"] is False
+    assert printer["host"] == "127.0.0.1"
+    assert printer["serial"] == "SERIAL1"
+    assert printer["last_error"] is None
 
     res = client.post("/api/p1/disconnect", headers=headers)
     assert res.status_code == 404


### PR DESCRIPTION
## Summary
- add PrinterInfo model to describe printer details
- return list[PrinterInfo] from /api/printers
- extend tests to validate new fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf25ddcbc832f8ca3bddae70a8b66

## Summary by Sourcery

Add a new PrinterInfo model and update the printers API endpoint to return structured PrinterInfo objects, with tests extended to cover the additional fields

New Features:
- Add PrinterInfo model to represent printer details
- Return typed list of PrinterInfo from /api/printers endpoint

Enhancements:
- Type annotate list_printers response as list[PrinterInfo]

Tests:
- Extend printer endpoint tests to assert host, serial, and last_error fields