### PR TITLE
Handle missing callback in connect

### DIFF
--- a/state.py
+++ b/state.py
@@ -145,10 +145,15 @@ async def _connect(
             )
 
             connect_method = c.connect
+            sig = inspect.signature(connect_method)
+            kwargs = {}
+            if "callback" in sig.parameters:
+                kwargs["callback"] = lambda evt: None
+
             if inspect.iscoroutinefunction(connect_method):
-                await connect_method(callback=lambda evt: None)
+                await connect_method(**kwargs)
             else:
-                await asyncio.to_thread(connect_method, callback=lambda evt: None)
+                await asyncio.to_thread(connect_method, **kwargs)
 
             deadline = time.monotonic() + max_wait
             while not c.connected and time.monotonic() < deadline:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -75,6 +75,22 @@ async def test_connect_coroutine(monkeypatch, state_module):
 
 
 @pytest.mark.asyncio
+async def test_connect_without_callback(monkeypatch, state_module):
+    class NoCallbackClient:
+        def __init__(self, *args, **kwargs):
+            self.host = kwargs["host"]
+            self.connected = False
+
+        def connect(self):
+            self.connected = True
+
+    monkeypatch.setattr(state_module, "BambuClient", NoCallbackClient)
+
+    c = await state_module._connect("p1")
+    assert c.connected is True
+
+
+@pytest.mark.asyncio
 async def test_connect_timeout_configurable(monkeypatch, state_module):
     class NeverClient:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- inspect the BambuClient connect method signature and pass `callback` only if supported
- add regression test for connect methods that do not accept a callback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9abca40832f94bdda98df158ef4