### PR TITLE
Add configuration read lock context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+### Configuration access
+
+Call `config._validate_env()` to reload environment settings at runtime.  Code
+that reads configuration values while a reload may be in progress should use
+the `config.read_lock()` context manager to obtain a consistent snapshot:
+
+```python
+import config
+
+with config.read_lock():
+    printers = list(config.PRINTERS)
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/config.py
+++ b/config.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import contextmanager
 from threading import Lock
 from types import MappingProxyType
-from typing import Dict, Mapping
+from typing import Dict, Mapping, Iterator
 from urllib.parse import urlparse
 
 log = logging.getLogger("bambubridge")
@@ -78,6 +79,13 @@ LAN_KEYS: Mapping[str, str] = MappingProxyType(_LAN_KEYS)
 TYPES: Mapping[str, str] = MappingProxyType(_TYPES)
 
 _CONFIG_LOCK = Lock()
+
+
+@contextmanager
+def read_lock() -> Iterator[None]:
+    """Acquire the configuration lock for safe concurrent reads."""
+    with _CONFIG_LOCK:
+        yield
 
 REGION = os.getenv("BAMBULAB_REGION", "US")
 EMAIL = os.getenv("BAMBULAB_EMAIL", "")


### PR DESCRIPTION
## Summary
- add `config.read_lock()` context manager guarding configuration reads
- use new context manager in API and state modules
- document config lock usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdfd5e28b4832fae8860512ee4fd1f