### PR TITLE
Deduplicate allowed origins

### DIFF
--- a/config.py
+++ b/config.py
@@ -125,7 +125,7 @@ def _load_allow_origins() -> list[str]:
             origins.append(origin)
         else:
             log.warning("Ignoring invalid origin '%s'", origin)
-    return origins or list(DEFAULT_ORIGINS)
+    return list(dict.fromkeys(origins or DEFAULT_ORIGINS))
 
 
 ALLOW_ORIGINS = _load_allow_origins()

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -99,7 +99,7 @@ def test_validate_env_duplicate(cfg, monkeypatch):
 def test_allow_origins_validation(monkeypatch, caplog, cfg):
     monkeypatch.setenv(
         "BAMBULAB_ALLOW_ORIGINS",
-        "http://good.com,not-a-url,https://ok.org,ftp://bad.com",
+        "http://good.com,not-a-url,https://ok.org,ftp://bad.com,http://good.com,https://ok.org",
     )
     with caplog.at_level(logging.WARNING):
         cfg._validate_env()


### PR DESCRIPTION
## Summary
- remove duplicate CORS origins while preserving order
- add regression test with duplicate entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be276e406c832f9fb19159f42ffba3