### PR TITLE
Resolve log level before configuration

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -13,18 +13,18 @@ from api import app
 def main() -> None:
     level_name = os.getenv("BAMBULAB_LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, None)
-    if not isinstance(level, int):
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(levelname)s:%(name)s:%(message)s",
-        )
+    invalid_level = not isinstance(level, int)
+    if invalid_level:
+        level = logging.INFO
+
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
+
+    if invalid_level:
         logging.warning(
             "Invalid log level %s provided, falling back to INFO", level_name
-        )
-    else:
-        logging.basicConfig(
-            level=level,
-            format="%(levelname)s:%(name)s:%(message)s",
         )
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))
 


### PR DESCRIPTION
## Summary
- derive desired log level once and configure logging in a single call
- keep warning when an invalid log level name is provided

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be2834fa4c832fa2ce75c06cb2a9e1