### PR TITLE
Add HealthzResult model and update health endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -256,15 +256,21 @@ class ActionResult(BaseModel):
     result: Dict[str, Any] = Field(default_factory=dict)
 
 
+class HealthzResult(BaseModel):
+    """Response model for the health check endpoint."""
+
+    printers: list[str] = Field(default_factory=list)
+
+
 # ---- routes ------------------------------------------------------------------
 
 
 @app.get("/healthz")
-async def healthz() -> StatusResult:
+async def healthz() -> HealthzResult:
     """Return API health status and list of known printers."""
     with config.read_lock():
         names = list(PRINTERS.keys())
-    return StatusResult(status={"printers": names})
+    return HealthzResult(printers=names)
 
 
 @app.get("/api/printers")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,7 +1,7 @@
 def test_health_and_printers(client):
     res = client.get("/healthz")
     assert res.status_code == 200
-    assert res.json()["status"]["printers"] == ["p1"]
+    assert res.json()["printers"] == ["p1"]
 
     res = client.get("/api/printers")
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- add `HealthzResult` Pydantic model
- return `HealthzResult` from `/healthz`
- adjust tests for new response structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be28cd6e4c832fb7949d730c44d6d2