### PR TITLE
Convert config lock to asyncio and test async reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,15 @@ pytest
 
 ### Configuration access
 
-Call `config._validate_env()` to reload environment settings at runtime.  Code
-that reads configuration values while a reload may be in progress should use
-the `config.read_lock()` context manager to obtain a consistent snapshot:
+Call `await config._validate_env()` to reload environment settings at runtime.
+Code that reads configuration values while a reload may be in progress should
+use the `async with config.read_lock()` context manager to obtain a consistent
+snapshot:
 
 ```python
 import config
 
-with config.read_lock():
+async with config.read_lock():
     printers = list(config.PRINTERS)
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,8 @@ def cfg(monkeypatch):
     monkeypatch.setenv("BAMBULAB_API_KEY", "secret")
     import config
     importlib.reload(config)
-    config._validate_env()
+    import asyncio
+    asyncio.run(config._validate_env())
     return config
 
 

--- a/tests/test_config_lock.py
+++ b/tests/test_config_lock.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_reads(cfg):
+    async def reader():
+        async with cfg.read_lock():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(
+        asyncio.gather(*(reader() for _ in range(5))),
+        timeout=1,
+    )

--- a/tests/test_env_helpers.py
+++ b/tests/test_env_helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from types import MappingProxyType
 
@@ -82,7 +83,7 @@ def test_validate_env_missing(cfg, monkeypatch):
     monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=k")
     monkeypatch.setenv("BAMBULAB_TYPES", "p1=X1C")
     with pytest.raises(RuntimeError) as exc:
-        cfg._validate_env()
+        asyncio.run(cfg._validate_env())
     assert "Missing BAMBULAB_SERIALS for p1" in str(exc.value)
 
 
@@ -92,7 +93,7 @@ def test_validate_env_multiple_missing(cfg, monkeypatch):
     monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=k")
     monkeypatch.setenv("BAMBULAB_TYPES", "")
     with pytest.raises(RuntimeError) as exc:
-        cfg._validate_env()
+        asyncio.run(cfg._validate_env())
     msg = str(exc.value)
     assert "Missing BAMBULAB_SERIALS for p1" in msg
     assert "Missing BAMBULAB_PRINTERS for p2" in msg
@@ -105,7 +106,7 @@ def test_validate_env_duplicate(cfg, monkeypatch):
     monkeypatch.setenv("BAMBULAB_LAN_KEYS", "a=k")
     monkeypatch.setenv("BAMBULAB_TYPES", "a=X1C")
     with pytest.raises(RuntimeError) as exc:
-        cfg._validate_env()
+        asyncio.run(cfg._validate_env())
     assert "Duplicate BAMBULAB_PRINTERS entry for 'a'" in str(exc.value)
 
 
@@ -115,7 +116,7 @@ def test_allow_origins_validation(monkeypatch, caplog, cfg):
         "http://good.com,not-a-url,https://ok.org,ftp://bad.com,http://good.com,https://ok.org",
     )
     with caplog.at_level(logging.WARNING):
-        cfg._validate_env()
+        asyncio.run(cfg._validate_env())
 
     assert cfg.ALLOW_ORIGINS == ["http://good.com", "https://ok.org"]
     assert "Ignoring invalid origin 'not-a-url'" in caplog.text
@@ -125,13 +126,13 @@ def test_allow_origins_validation(monkeypatch, caplog, cfg):
 def test_validate_env_rereads_api_key_and_origins(monkeypatch, cfg):
     monkeypatch.setenv("BAMBULAB_API_KEY", "first")
     monkeypatch.setenv("BAMBULAB_ALLOW_ORIGINS", "http://one.com")
-    cfg._validate_env()
+    asyncio.run(cfg._validate_env())
     assert cfg.API_KEY == "first"
     assert cfg.ALLOW_ORIGINS == ["http://one.com"]
 
     monkeypatch.setenv("BAMBULAB_API_KEY", "second")
     monkeypatch.setenv("BAMBULAB_ALLOW_ORIGINS", "http://two.com")
-    cfg._validate_env()
+    asyncio.run(cfg._validate_env())
     assert cfg.API_KEY == "second"
     assert cfg.ALLOW_ORIGINS == ["http://two.com"]
 
@@ -141,7 +142,7 @@ def test_config_readonly_and_copy(monkeypatch, cfg):
     monkeypatch.setenv("BAMBULAB_SERIALS", "p1=s")
     monkeypatch.setenv("BAMBULAB_LAN_KEYS", "p1=k")
     monkeypatch.setenv("BAMBULAB_TYPES", "p1=X1C")
-    cfg._validate_env()
+    asyncio.run(cfg._validate_env())
 
     assert isinstance(cfg.PRINTERS, MappingProxyType)
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -19,7 +19,8 @@ def api_autoconnect(monkeypatch):
     import state
     import api
     importlib.reload(config)
-    config._validate_env()
+    import asyncio
+    asyncio.run(config._validate_env())
     importlib.reload(state)
     importlib.reload(api)
     return state, api


### PR DESCRIPTION
## Summary
- replace configuration Lock with `asyncio.Lock` and expose async `read_lock`
- update API/state code to use `async with config.read_lock()` and async `_validate_env`
- document new usage and add test ensuring concurrent reads don't deadlock

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5501f86d8832f97913bebcda99dbb