### PR TITLE
Remove connect lock on disconnect

### DIFF
--- a/api.py
+++ b/api.py
@@ -321,8 +321,7 @@ async def disconnect_now(name: str) -> ActionResult:
             await asyncio.to_thread(fn)
     except Exception as e:  # pragma: no cover - network failures
         raise HTTPException(502, detail=f"disconnect failed: {type(e).__name__}: {e}")
-    async with state.write_lock:
-        state.clients.pop(name, None)
+    await state.discard_client(name)
     return ActionResult(result={"name": name})
 
 


### PR DESCRIPTION
## Summary
- drop printer connect lock when disconnecting via new `PrinterState.discard_client`
- ensure `PrinterState.clear()` discards clients and locks
- add test verifying disconnect frees connect lock

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5614c5ae8832f9f4e68b3d7919ed5