### PR TITLE
Add tests for bridge logging level and port configuration

### DIFF
--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,20 @@
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+
+def test_invalid_log_level_warn_and_port_passed(monkeypatch, caplog):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    import bridge
+
+    mock_run = Mock()
+    monkeypatch.setattr(bridge.uvicorn, "run", mock_run)
+    monkeypatch.setenv("BAMBULAB_LOG_LEVEL", "BADLEVEL")
+    monkeypatch.setenv("PORT", "1234")
+
+    with caplog.at_level(logging.WARNING):
+        bridge.main()
+
+    assert "Invalid log level BADLEVEL provided, falling back to INFO" in caplog.text
+    mock_run.assert_called_once_with(bridge.app, host="0.0.0.0", port=1234)


### PR DESCRIPTION
## Summary
- add unit test for bridge.main that warns on invalid log level and forwards PORT to uvicorn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5624fdff4832fadcde4150b2565c2

## Summary by Sourcery

Add unit test for bridge.main to ensure invalid log levels log warnings and environment PORT is forwarded to uvicorn

Tests:
- Add test for invalid log level warning and fallback to INFO
- Add test to verify PORT environment variable is passed to uvicorn.run