### PR TITLE
Handle invalid port environment variable

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -26,7 +26,16 @@ def main() -> None:
         logging.warning(
             "Invalid log level %s provided, falling back to INFO", level_name
         )
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8088")))
+    port_env = os.getenv("PORT", "8088")
+    try:
+        port = int(port_env)
+    except ValueError:
+        port = 8088
+        logging.warning(
+            "Invalid port %s provided, falling back to 8088",
+            port_env,
+        )
+    uvicorn.run(app, host="0.0.0.0", port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid crashing on invalid PORT env by defaulting to 8088 and logging a warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c569870784832f9ae407bc7bb806de