### PR TITLE
Handle ValueError when inspecting print function signature

### DIFF
--- a/api.py
+++ b/api.py
@@ -184,7 +184,10 @@ async def _invoke_print(
     how to pass the ``gcode_url`` and optional ``thmf_url`` parameters.
     """
 
-    sig = inspect.signature(fn)
+    try:
+        sig = inspect.signature(fn)
+    except ValueError as e:
+        raise TypeError("Function signature cannot be inspected") from e
     param_names = [p.name for p in sig.parameters.values()]
 
     args: list[Any] = []


### PR DESCRIPTION
## Summary
- handle ValueError when inspecting print function signatures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56d1cc2ac832fa5e5ff5e0bc0704d