### PR TITLE
Annotate camera route with StreamingResponse

### DIFF
--- a/api.py
+++ b/api.py
@@ -391,7 +391,7 @@ async def stop(name: str) -> ActionResult:
 
 
 @app.get("/api/{name}/camera", dependencies=[Depends(require_api_key)])
-async def camera(name: str):
+async def camera(name: str) -> StreamingResponse:
     """Stream the printer camera as an MJPEG ``StreamingResponse``.
 
     Supports both synchronous and asynchronous ``camera_mjpeg`` implementations


### PR DESCRIPTION
## Summary
- type-hint camera endpoint to return StreamingResponse

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c56d94e3fc832f9844e5f5401a1a82

## Summary by Sourcery

Enhancements:
- Add explicit StreamingResponse type hint to the camera endpoint